### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/blue-green-deploy.yml
+++ b/.github/workflows/blue-green-deploy.yml
@@ -63,8 +63,8 @@ jobs:
           fi
           echo 'new deployment: ' $NEWDEPLOYMENT
           echo 'active deployment': $ACTIVEDEPLOYMENT
-          echo "::set-output name=NEWDEPLOYMENT::$NEWDEPLOYMENT"
-          echo "::set-output name=ACTIVEDEPLOYMENT::$ACTIVEDEPLOYMENT"
+          echo "NEWDEPLOYMENT=$NEWDEPLOYMENT" >> "$GITHUB_OUTPUT"
+          echo "ACTIVEDEPLOYMENT=$ACTIVEDEPLOYMENT" >> "$GITHUB_OUTPUT"
           NEWDEPLOYMENTEXISTS=$(az spring-cloud app deployment list -s ${{env.SPRING_CLOUD_SERVICE}} -g ${{env.AZURE_RESOURCEGROUP_NAME}} --app ${{env.APP_NAME}} --query "[?name=='$NEWDEPLOYMENT'].name" -o tsv)
           if [ "$NEWDEPLOYMENTEXISTS" = "$NEWDEPLOYMENT" ]; then
             echo $NEWDEPLOYMENT ' already exists'


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter